### PR TITLE
Disabling required password change and Windows PowerShell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ simply open your browser and visit `https://localhost:8080/vnc.html`.
 ## Installation
 1) Clone this repository
 2) Open a terminal and run `bash install.sh` in the repository root
+    - On Windows you can use the `install.ps1` script with PowerShell
 3) Follow the instructions in the terminal
 
 ## Uninstallation
 1) Open a terminal and run `bash uninstall.sh` in the repository root
+    - On Windows you can use the `uninstall.ps1` script with PowerShell
 
 ## Notes
 This was last tested with the Bee-Up 1.6 release for macOS (`sha1sum: 7e323785a46c0a438144abf1b19cb19d43d64fea`)

--- a/home/app/start_app.sh
+++ b/home/app/start_app.sh
@@ -9,7 +9,6 @@ then
   # Initialize database
   /opt/mssql-tools/bin/sqlcmd -S ${DATABASE_HOST} -U SA -P ${SA_PASSWORD} -i "${HOME}/createUser.sql"
   /opt/mssql-tools/bin/sqlcmd -S ${DATABASE_HOST} -U SA -P ${SA_PASSWORD} -i "${HOME}/createDB.sql"
-  /opt/mssql-tools/bin/sqlcmd -S ${DATABASE_HOST} -U SA -P ${SA_PASSWORD} -i "${HOME}/postprocess.sql"
 
   touch "${HOME}/data/initialized_db"
 fi
@@ -27,8 +26,11 @@ EOF
   odbcinst -i -s ${DATABASE} -f "${HOME}/odbc.ini"
   wine "C:/Program Files/BOC/${TOOLFOLDER}/adbinst.exe" -d${DATABASE} -l${LICENSE_KEY} -sSQLServer -iNO_SSO -lang2057
 
+  # Disables the required password change
+  /opt/mssql-tools/bin/sqlcmd -S ${DATABASE_HOST} -U SA -P ${SA_PASSWORD} -i "${HOME}/postprocess.sql"
+
   # Remember that Bee-Up was intialized
   touch "${HOME}/initialized_app"
 fi
 
-wine "${WINEPREFIX}"/drive_c/Program\ Files/BOC/BEEUP16_ADOxx_SA/areena.exe -uAdmin -d${DATABASE}
+wine "${WINEPREFIX}"/drive_c/Program\ Files/BOC/BEEUP16_ADOxx_SA/areena.exe -uAdmin -ppassword -d${DATABASE}

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,65 @@
+# For Windows PowerShell (tested 5.1.19041.1320)
+# and PowerShell (tested 7.1.4)
+
+Write-Host "============================================================"
+$download_beeup = Read-Host "Download Bee-up 1.6? (y|n) "
+Write-Host "============================================================"
+
+if ($download_beeup -eq 'y') {
+  Invoke-WebRequest -OutFile ".\home\app\beeup.zip" `
+    -Uri "https://bee-up.omilab.org/files/tool-installer/Bee-Up_1.6_64-bit_macOS-prototype.zip"
+  Expand-Archive ".\home\app\beeup.zip" `
+    -DestinationPath ".\home\app"
+  Remove-Item ".\home\app\beeup.zip"
+} else {
+  Write-Host "============================================================"
+  Write-Host "Installer expects that you've downloaded Bee-up by yourself"
+  Write-Host "and unzipped it to .\home\app\bee-up-master-TOOL"
+  Write-Host "============================================================"
+  if (-Not (Test-Path -Path ".\home\app\bee-up-master-TOOL")) {
+    Write-Host ".\home\app\bee-up-master-TOOL not found."
+    Write-Host "Aborting installation."
+    Write-Host "============================================================"
+    Exit
+  }
+}
+
+
+docker version 2>&1 | Out-Null
+$docker_running = $?
+if (-Not $docker_running) {
+  Write-Host "============================================================"
+  Write-Host "It appears that docker is not running. Please start docker"
+  Write-Host "and run this script again. To install docker, see:"
+  Write-Host "https://docs.docker.com/get-docker/"
+  Write-Host "============================================================"
+  Exit
+}
+
+
+Write-Host "============================================================"
+Write-Host "Running generic installation procedure..."
+Write-Host "============================================================"
+
+docker build . -t beeup:latest
+
+docker run --name beeup `
+  --restart unless-stopped `
+  -d `
+  -p 8080:8080 `
+  -v beeup:/home/app/data `
+  beeup:latest
+
+
+Write-Host "============================================================"
+Write-Host "You have to finish the installation manually:"
+Write-Host "1) Open http://localhost:8080/vnc.html in your favorite"
+Write-Host "   browser and click 'Connect'. The password to connect is"
+Write-Host "   'password'."
+Write-Host "2) Then click through the installation process and wait."
+Write-Host "3) Wait some more."
+Write-Host
+Write-Host "That should be it, you're good to go."
+Write-Host "============================================================"
+# Pause in case the PowerShell script is executed from context menu
+Read-Host -Prompt "Press any key to continue"

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,14 @@
+# For Windows PowerShell (tested 5.1.19041.1320)
+# and PowerShell (tested 7.1.4)
+
+docker stop beeup
+docker rm beeup
+docker volume rm beeup
+docker rmi beeup:latest
+
+Write-Host "============================================================"
+Write-Host "Done. You can remove the cloned repository too. I hope you"
+Write-Host "passed MOD."
+Write-Host "============================================================"
+# Pause in case the PowerShell script is executed from context menu
+Read-Host -Prompt "Press any key to continue"


### PR DESCRIPTION
Hi,

Implemented two changes:
* The `postprocess.sql` is used to disable the required password change when starting the tool for the first time, but it has to be executed after the database has been initialized. Moved that part in the `start_app.sh`
* Two PowerShell scripts (`install.ps1` and `uninstall.ps1`) to make the use on windows easier. PowerShell is installed on Windows by default starting from Windows 7 SP1 and Windows Server 2008 R2 SP1 as far as I know.

Best regards,
Patrik